### PR TITLE
Run type check in pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,3 +3,4 @@
 
 npx lint-staged
 npm run test
+npx tsc --noEmit --skipLibCheck


### PR DESCRIPTION
## Description

This runs the TypeScript compiler in the pre-commit hook.

Resolves #21 

## Decisions / Choices I made

Not all type errors are caught by the linter, so I think this makes sense to prevent errors early.

## Checklist

- [x] All checks pass successfully
- [x] All related commits are squashed together
- [x] The changes are properly documented / the relevant documentation is updated (if applicable)
- [x] Appropriate labels are added to this pull request
