### PR TITLE
Display remaining attempts after submitting a wrong answer

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -289,5 +289,31 @@ describe('App component', () => {
       indexTextEl = screen.getByText('2 of 2');
       expect(indexTextEl).toBeInTheDocument();
     });
+
+    it('displays the remaining attempts after wrongly answering a question', async () => {
+      const user = userEvent.setup();
+
+      render(<App data={testDataWithFourQuestions}></App>, {
+        wrapper: translationsProvider,
+      });
+
+      // A quick set of a test with four questions contains 1 question
+      const button = screen.getByText(/Quick set/i);
+      await user.click(button);
+
+      for (let i = 0; i < 2; i++) {
+        await answerQuestionIncorrectly(user);
+        const attemptLeft = i === 1 ? 'attempt' : 'attempts';
+        const notCorrectText = screen.getByText(
+          `Your answer was not correct. You have ${2 - i} ${attemptLeft} left.`,
+        );
+        expect(notCorrectText).toBeInTheDocument();
+        await user.click(screen.getByText('Next Question'));
+      }
+
+      await answerQuestionIncorrectly(user);
+      const lastAttemptText = screen.getByText(`Your answer was not correct.`);
+      expect(lastAttemptText).toBeInTheDocument();
+    });
   });
 });

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -143,6 +143,7 @@ const Form = ({
         <Question
           text={question.text}
           type={question.type}
+          attempts={question.remainingAttempts}
           showResult={submitted}
           isCorrect={isCorrect}
         />

--- a/src/components/Question.tsx
+++ b/src/components/Question.tsx
@@ -6,11 +6,13 @@ import Markdown from './Markdown';
 const Question = ({
   text,
   type,
+  attempts,
   showResult,
   isCorrect,
 }: {
   text: string;
   type: QuizType;
+  attempts: number;
   showResult: boolean;
   isCorrect: boolean;
 }) => {
@@ -23,7 +25,9 @@ const Question = ({
 
       {showResult ? (
         <p className={styles.hint}>
-          {isCorrect ? t('question.correct') : t('question.notCorrect')}
+          {isCorrect
+            ? t('question.correct')
+            : `${t('question.notCorrect')} ${attempts > 1 ? t('question.remainingAttempts', { count: attempts - 1 }) : ''}`}
         </p>
       ) : (
         <p className={styles.hint}>

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -22,8 +22,10 @@ const de = {
     yesBtn: 'Ja',
   },
   question: {
-    correct: 'Ihre Antwort war richtig ✅',
-    notCorrect: 'Ihre Antwort war nicht richtig ❌',
+    correct: 'Ihre Antwort war richtig.',
+    notCorrect: 'Ihre Antwort war nicht richtig.',
+    remainingAttempts_one: 'Sie haben noch {{count}} Versuch.',
+    remainingAttempts_other: 'Sie haben noch {{count}} Versuche.',
     selectAll: 'Wählen Sie alle richtigen Antworten aus.',
     selectOne: 'Wählen Sie die richtige Antwort aus.',
   },

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -23,8 +23,10 @@ const en = {
     yesBtn: 'Yes',
   },
   question: {
-    correct: 'Your answer was correct ✅',
-    notCorrect: 'Your answer was not correct ❌',
+    correct: 'Your answer was correct.',
+    notCorrect: 'Your answer was not correct.',
+    remainingAttempts_one: 'You have {{count}} attempt left.',
+    remainingAttempts_other: 'You have {{count}} attempts left.',
     selectAll: 'Select all correct answers.',
     selectOne: 'Select the correct answer.',
   },


### PR DESCRIPTION
## Description

After the submission of a wrong answer the user now sees the number of attempts left. We also decided to remove the icon.

 
![Screenshot 2024-04-19 at 15 22 07](https://github.com/openHPI/quiz-recap/assets/62883011/4f23daa9-ef75-4b4d-b02e-ff9790489021)

## Checklist

- [x] All checks pass successfully
- [x] All related commits are squashed together
- [ ] The changes are properly documented / the relevant documentation is updated (if applicable)
- [x] Appropriate labels are added to this pull request
