### PR TITLE
Fix spacing in results table and answer box 

### DIFF
--- a/src/components/Answers.module.scss
+++ b/src/components/Answers.module.scss
@@ -14,7 +14,7 @@
   display: flex;
   align-items: center;
   border-radius: 4px;
-  padding: 8px 8px 8px 16px;
+  padding-left: 15px;
 
   &.default {
     background-color: variables.$neutral-light;
@@ -43,7 +43,7 @@
   justify-content: space-between;
   align-items: center;
   width: 100%;
-  padding: 0 8px;
+  padding: 15px;
 
   * {
     margin: 0px;

--- a/src/components/Result.module.scss
+++ b/src/components/Result.module.scss
@@ -25,11 +25,11 @@
 
   .th {
     text-align: left;
-    padding: 16px 0;
+    padding: 16px 8px;
   }
 
   .td {
-    padding: 16px 0;
+    padding: 16px 8px;
     * {
       margin: 0;
     }


### PR DESCRIPTION
## Description

This PR fixes some horizontal spacing missing in the results table, specially noticeable with long questions

| before | after |
|----|----|
| ![image](https://github.com/openHPI/quiz-recap/assets/62883011/fb499558-fba6-4fb6-9bd6-5b78a36ea39a) | ![Screenshot 2024-04-19 at 16 10 45](https://github.com/openHPI/quiz-recap/assets/62883011/5d8ad369-e9e4-489d-8428-27b858383af6) |

In the second commit it also restructures the spacing in the answers box so that the user can click anywhere on it to select the answer. This does not introduce any visual change.

## Checklist

- [x] All checks pass successfully
- [x] All related commits are squashed together
- [ ] The changes are properly documented / the relevant documentation is updated (if applicable)
- [x] Appropriate labels are added to this pull request
