### PR TITLE
Improve responsiveness for mobile devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,10 +12,11 @@
       }
 
       .container {
-        max-width: 850px;
-        margin: auto;
-        margin-top: 20px;
-        padding: 20px;
+        @media screen and (min-width: 580px) {
+          max-width: 850px;
+          margin: 20px auto;
+          padding: 20px;
+        }
       }
     </style>
   </head>

--- a/src/App.module.scss
+++ b/src/App.module.scss
@@ -31,6 +31,10 @@
   }
 
   .button {
-    width: 50%;
+    width: 100%;
+
+    @include variables.screen-size-s-and-up {
+      width: 50%;
+    }
   }
 }

--- a/src/components/Answers.module.scss
+++ b/src/components/Answers.module.scss
@@ -44,8 +44,30 @@
   align-items: center;
   width: 100%;
   padding: 15px;
+  flex-wrap: wrap;
+
+  > *:first-child {
+    margin-right: 10px;
+  }
 
   * {
     margin: 0px;
+  }
+
+  .correctHint {
+    display: none;
+    @include variables.screen-size-m-and-up {
+      display: block;
+    }
+  }
+
+  code {
+    // Ensure code elements don't overflow
+    white-space: pre-wrap;
+  }
+
+  img {
+    // Ensure images don't overflow
+    max-width: 100%;
   }
 }

--- a/src/components/Answers.tsx
+++ b/src/components/Answers.tsx
@@ -63,7 +63,9 @@ const Answers = ({
             ></input>
             <label className={styles.label} htmlFor={answer.id}>
               <Markdown content={answer.text}></Markdown>
-              {showCorrect && <p>{correctHint}</p>}
+              {showCorrect && (
+                <p className={styles.correctHint}>{correctHint}</p>
+              )}
             </label>
           </div>
         );

--- a/src/components/Question.module.scss
+++ b/src/components/Question.module.scss
@@ -5,6 +5,10 @@
 
   .text {
     margin-bottom: 20px;
+    img {
+      // Ensure images don't overflow
+      max-width: 100%;
+    }
   }
 
   .hint {

--- a/src/static/data.ts
+++ b/src/static/data.ts
@@ -171,6 +171,19 @@ export const exampleData: Data = [
       },
     ],
   },
+  {
+    id: '12',
+    type: QuestionTypes.SingleChoice,
+    text: `![Image](https://picsum.photos/600/200)`,
+    answers: [
+      { id: 'a', correct: true, text: 'Nice image' },
+      {
+        id: 'b',
+        correct: false,
+        text: 'Ugly image',
+      },
+    ],
+  },
 ];
 
 export const testData: Data = [

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -26,3 +26,15 @@ $danger-dark: var(--qr-color-danger-dark, hsl(0, 72%, 51%));
   font-size: 20px;
   line-height: 28px;
 }
+
+@mixin screen-size-s-and-up($width: 580px) {
+  @media (min-width: $width) {
+    @content;
+  }
+}
+
+@mixin screen-size-m-and-up($width: 800px) {
+  @media (min-width: $width) {
+    @content;
+  }
+}


### PR DESCRIPTION
## Description

This PR improves the responsiveness of the application by:

- Introducing media breakpoints
- Removing answers "Correct/Incorrect" hint on small screens ( this information is available via color code)
- Ensuring contents don't overflow the questions and answers containers
- Expanding the main buttons on small screens
- Adjusting the app container on small screens

<details><summary>See screenshots</summary>

| before | after |
|--------|--------|
| ![Screenshot 2024-04-25 at 14 43 35](https://github.com/openHPI/quiz-recap/assets/62883011/923eb217-56d8-49b8-b99d-940451c3ee57) | ![Screenshot 2024-04-25 at 14 43 17](https://github.com/openHPI/quiz-recap/assets/62883011/4ba25293-89c9-42e9-8d53-5b9847e93cc0) |
| ![Screenshot 2024-04-25 at 14 46 19](https://github.com/openHPI/quiz-recap/assets/62883011/7064224e-785c-4fab-873a-e09fc648715a)|![Screenshot 2024-04-25 at 14 47 12](https://github.com/openHPI/quiz-recap/assets/62883011/daa419a7-4080-4005-beed-19f035a32e14)|
![Screenshot 2024-04-25 at 14 46 04](https://github.com/openHPI/quiz-recap/assets/62883011/ecd5aee0-6e56-43f8-b596-41801f1b9a64) | ![Screenshot 2024-04-25 at 14 45 29](https://github.com/openHPI/quiz-recap/assets/62883011/0bb26428-d308-49a6-b9f0-e02f38d290aa)|

</details> 

## Decisions / Choices I made

It also extends the data with an image question

## Checklist

- [x] All checks pass successfully
- [x] All related commits are squashed together
- [ ] The changes are properly documented / the relevant documentation is updated (if applicable)
- [x] Appropriate labels are added to this pull request
