### PR TITLE
Run tests pre-push instead of pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,3 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 npx lint-staged
-npx tsc --noEmit --skipLibCheck

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npx lint-staged
-npx tsc --noEmit --skipLibCheck
+npm run test

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -2,3 +2,4 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 npm run test
+npx tsc --noEmit --skipLibCheck


### PR DESCRIPTION
## Description

This PR runs the test pre-push instead of pre-commit.

Resolves #78

## Decisions / Choices I made

Committing changes should be fast. For a while it was fine but as we wrote more and more test, it felt sluggish.
So for the same reason I decided to tun the TypeScript compiler `pre-push` in the second commit.

## Checklist

- [x] All checks pass successfully
- [x] All related commits are squashed together
- [x] The changes are properly documented / the relevant documentation is updated (if applicable)
- [x] Appropriate labels are added to this pull request
