### PR TITLE
Styles refinement

### DIFF
--- a/src/components/Answers.module.scss
+++ b/src/components/Answers.module.scss
@@ -6,6 +6,9 @@
 
 .answers {
   min-height: 32px;
+  * {
+    @include variables.font-s;
+  }
 
   &:not(:last-child) {
     margin-bottom: 8px;

--- a/src/components/Answers.module.scss
+++ b/src/components/Answers.module.scss
@@ -67,6 +67,7 @@
   code {
     // Ensure code elements don't overflow
     white-space: pre-wrap;
+    word-break: break-all;
   }
 
   img {

--- a/src/components/Answers.module.scss
+++ b/src/components/Answers.module.scss
@@ -47,11 +47,6 @@
   align-items: center;
   width: 100%;
   padding: 15px;
-  flex-wrap: wrap;
-
-  > *:first-child {
-    margin-right: 10px;
-  }
 
   * {
     margin: 0px;
@@ -61,6 +56,7 @@
     display: none;
     @include variables.screen-size-m-and-up {
       display: block;
+      margin-left: 20px;
     }
   }
 

--- a/src/components/Answers.tsx
+++ b/src/components/Answers.tsx
@@ -62,7 +62,9 @@ const Answers = ({
               disabled={showCorrect}
             ></input>
             <label className={styles.label} htmlFor={answer.id}>
-              <Markdown content={answer.text}></Markdown>
+              <div>
+                <Markdown content={answer.text}></Markdown>
+              </div>
               {showCorrect && (
                 <p className={styles.correctHint}>{correctHint}</p>
               )}

--- a/src/components/Button.module.scss
+++ b/src/components/Button.module.scss
@@ -6,7 +6,7 @@
   min-height: 32px;
   color: white;
   border: none;
-  @include variables.font-m;
+  @include variables.font-s;
 
   &.primary {
     background-color: variables.$primary;

--- a/src/components/Question.module.scss
+++ b/src/components/Question.module.scss
@@ -5,6 +5,12 @@
 
   .text {
     margin-bottom: 20px;
+    code {
+      // Ensure code elements don't overflow
+      white-space: pre-wrap;
+      word-break: break-all;
+    }
+
     img {
       // Ensure images don't overflow
       max-width: 100%;

--- a/src/components/Result.module.scss
+++ b/src/components/Result.module.scss
@@ -22,6 +22,7 @@
     border-bottom: 1px solid;
     border-top: 1px solid;
     background-color: white;
+    @include variables.font-s;
 
     &:hover {
       background-color: variables.$neutral-light;
@@ -37,6 +38,7 @@
   .th {
     text-align: left;
     padding: 16px 8px;
+    @include variables.font-s;
   }
 
   .td {

--- a/src/components/ResultViewer.module.scss
+++ b/src/components/ResultViewer.module.scss
@@ -31,6 +31,8 @@
 
 .answers {
   padding-left: 0;
+  margin-block-end: 0;
+  margin-block-start: 16px;
 }
 
 .answer {

--- a/src/components/ResultViewer.module.scss
+++ b/src/components/ResultViewer.module.scss
@@ -35,6 +35,7 @@
 
 .answer {
   display: flex;
+  justify-content: space-between;
   align-items: center;
   border-radius: 4px;
   width: 100%;
@@ -65,14 +66,16 @@
     margin: 0;
   }
 
-  .answerMarkdown {
-    flex-grow: 1;
+  .iconAndAnswer {
+    display: flex;
+    align-items: center;
   }
 
   .correctHint {
     display: none;
     @include variables.screen-size-m-and-up {
       display: block;
+      margin-left: 20px;
     }
   }
 

--- a/src/components/ResultViewer.module.scss
+++ b/src/components/ResultViewer.module.scss
@@ -10,6 +10,8 @@
     * {
       font-weight: normal;
       text-decoration: none;
+    }
+    *:not(pre) {
       display: inline;
     }
   }

--- a/src/components/ResultViewer.tsx
+++ b/src/components/ResultViewer.tsx
@@ -53,14 +53,16 @@ const ResultViewer = ({
             className={`${styles.answer} ${indicatorClass(answer)} ${selectedClass(answer)}`}
             aria-description={wasSelected(answer) ? t('viewer.selected') : ''}
           >
-            <FontAwesomeIcon
-              icon={icon(answer)}
-              className={styles.icon}
-              aria-label={correctHint(answer)}
-              title={correctHint(answer)}
-            />
-            <div className={styles.answerMarkdown}>
-              <Markdown content={answer.text} />
+            <div className={styles.iconAndAnswer}>
+              <FontAwesomeIcon
+                icon={icon(answer)}
+                className={styles.icon}
+                aria-label={correctHint(answer)}
+                title={correctHint(answer)}
+              />
+              <div className={styles.answerMarkdown}>
+                <Markdown content={answer.text} />
+              </div>
             </div>
             <p className={styles.correctHint}>{correctHint(answer)}</p>
           </li>


### PR DESCRIPTION
## Description

This PR fixes some styling issues and other style improvements:

- **Commit 1**: Sets the `font-size` property to elements that had none defined and could potentially be overwritten with values that did not match the rest of the styles. This commit also decrease the buttons font-size

  <details><summary>Details</summary>

  | before | after |
  |--------|--------|
  |<img width="784" alt="Screenshot 2024-05-03 at 14 30 25" src="https://github.com/openHPI/quiz-recap/assets/62883011/6e564892-8574-491c-8621-7575d188006d"> |<img width="783" alt="Screenshot 2024-05-03 at 14 29 46" src="https://github.com/openHPI/quiz-recap/assets/62883011/129b60e8-a7d3-4c74-9c75-a851b85fa795"> | 
  </details> 


- **Commit 2**: Improve display of codeblocks:

  <details><summary>Details</summary>

    | before | after |
    |--------|--------|
    | <img width="295" alt="Screenshot 2024-05-03 at 14 40 28" src="https://github.com/openHPI/quiz-recap/assets/62883011/1da9c4e7-078a-48bc-9938-2f92ee9ef0ab"> | <img width="285" alt="Screenshot 2024-05-03 at 14 40 02" src="https://github.com/openHPI/quiz-recap/assets/62883011/ee985a44-a063-4d91-9bf8-b849883b005c">|
  </details> 


- **Commit 3**: Multiline answers were not properly displayed
  
  <details><summary>Details</summary>

    | before | after |
    |--------|--------|
    | <img width="780" alt="Screenshot 2024-05-03 at 14 08 08" src="https://github.com/openHPI/quiz-recap/assets/62883011/e9cf610e-6536-4a5d-944c-8f82f6bdbe7f"> | <img width="785" alt="Screenshot 2024-05-03 at 14 07 18" src="https://github.com/openHPI/quiz-recap/assets/62883011/9c011d5c-75d8-4f5f-82c2-683498674b89">|
  </details>

- **Commit 4**: Prevent hint text from moving down to a new line. (See "Incorrect" hint from image above)

-  **Commit 5**: Prevents code elements from taking all horizontal space and ensures space between hint and text. Fixes: https://dev.xikolo.de/youtrack/issue/XI-6369#focus=Comments-71-49361.0-0 

    <details><summary>Details</summary>

    | before | after |
    |--------|--------|
    | <img width="827" alt="Screenshot 2024-05-03 at 14 46 33" src="https://github.com/openHPI/quiz-recap/assets/62883011/a9af27f8-5e4b-4fad-af9b-4cfe6e646ad0"> |  <img width="859" alt="Screenshot 2024-05-03 at 14 46 50" src="https://github.com/openHPI/quiz-recap/assets/62883011/aa8de4ff-44b9-4d86-8f57-9ba1be100182">|
  </details>

- **Commit 6**: Set margin properties to resultViewer `ul` element. Otherwise they can be overwritten by external CSS. Fixes: https://dev.xikolo.de/youtrack/issue/XI-6369#focus=Comments-71-49374.0-0

## Decisions / Choices I made

## Checklist

- [x] All checks pass successfully
- [x] All related commits are squashed together
- [x] Appropriate labels are added to this pull request
