### PR TITLE
Adapt color coding of submitted answers

### DIFF
--- a/src/components/Answers.module.scss
+++ b/src/components/Answers.module.scss
@@ -28,7 +28,11 @@
   }
 
   &.wrong {
-    background-color: variables.$danger-light;
+    background-color: variables.$neutral-light;
+
+    &:has(> input:checked) {
+      background-color: variables.$danger-light;
+    }
   }
 }
 

--- a/src/components/ResultViewer.module.scss
+++ b/src/components/ResultViewer.module.scss
@@ -45,6 +45,7 @@
   margin: 5px 0;
   box-sizing: border-box;
   flex-wrap: nowrap;
+  background-color: variables.$neutral-light;
 
   &.selected {
     font-weight: bold;

--- a/src/components/ResultViewer.tsx
+++ b/src/components/ResultViewer.tsx
@@ -24,8 +24,11 @@ const ResultViewer = ({
   const wasSelected = (answer: AnswerType) =>
     selectedAnswers.some((sel) => sel.id === answer.id);
 
-  const indicatorClass = (answer: AnswerType) =>
-    answer.correct ? styles.correct : styles.wrong;
+  const indicatorClass = (answer: AnswerType) => {
+    if (answer.correct) return styles.correct;
+
+    if (wasSelected(answer) && !answer.correct) return styles.wrong;
+  };
 
   const selectedClass = (answer: AnswerType) =>
     wasSelected(answer) ? styles.selected : '';


### PR DESCRIPTION
## Description

This PR changes the color coding of submitted answers.
As described in #81.

### Correct answer

![Screenshot 2024-05-10 at 10 24 54](https://github.com/openHPI/quiz-recap/assets/22977799/58d25a5a-eef8-4207-951d-b93f7ae30c14)

### Partly correct answer

![Screenshot 2024-05-10 at 10 24 42](https://github.com/openHPI/quiz-recap/assets/22977799/d07e15d7-0de9-41c1-a246-1dd0788f693b)


### Wrong answer

![Screenshot 2024-05-10 at 10 24 30](https://github.com/openHPI/quiz-recap/assets/22977799/5cc70d90-34a8-410f-a543-6437839b81ef)

### Result

![Screenshot 2024-05-10 at 10 25 27](https://github.com/openHPI/quiz-recap/assets/22977799/4aa4fde6-82f8-4dcd-bd0f-7957bcb331a1)

Resolves #81

## Decisions / Choices I made

All answers have a default light-grey color in the `ResultViewer`.

The adjustment could be made with pure CSS on the `Answers` component. The `ResultViewer` does not have a `input:checked`, so I had to use JS.

## Checklist

- [x] All checks pass successfully
- [x] All related commits are squashed together
- [x] The changes are properly documented / the relevant documentation is updated (if applicable)
- [x] Appropriate labels are added to this pull request
