### PR TITLE
Add border to Answers in Results table for visibility 

### DIFF
--- a/src/components/Result.module.scss
+++ b/src/components/Result.module.scss
@@ -25,7 +25,7 @@
     @include variables.font-s;
 
     &:hover {
-      background-color: hsl(0, 0%, 99%);
+      background-color: variables.$neutral-light;
     }
   }
 
@@ -54,6 +54,7 @@
   .chevronIcon {
     color: variables.$neutral-dark;
     @include variables.font-s;
+    cursor: pointer;
   }
 
   .correctIcon {

--- a/src/components/ResultViewer.module.scss
+++ b/src/components/ResultViewer.module.scss
@@ -45,18 +45,26 @@
   margin: 5px 0;
   box-sizing: border-box;
   flex-wrap: nowrap;
-  background-color: variables.$neutral-light;
+  background-color: white;
+  border: 1px solid;
+  border-color: variables.$border-neutral;
 
   &.selected {
     font-weight: bold;
+
+    .icon {
+      color: variables.$neutral-dark;
+    }
   }
 
   &.correct {
     background-color: variables.$success-light;
+    border-color: variables.$success;
   }
 
   &.wrong {
     background-color: variables.$danger-light;
+    border-color: variables.$danger;
   }
 
   .icon {

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -5,6 +5,8 @@ $neutral: var(--qr-color-neutral, hsl(0, 0%, 45%));
 $neutral-light: var(--qr-color-neutral-light, hsl(0, 0%, 96%));
 $neutral-dark: var(--qr-color-neutral-dark, hsl(0, 0%, 32%));
 
+$border-neutral: hsl(from $neutral-light h s 80%);
+
 $success: var(--qr-color-success, hsl(142, 71%, 45%));
 $success-light: var(--qr-color-success-light, hsl(142, 77%, 73%));
 $success-dark: var(--qr-color-success-dark, hsl(142, 76%, 36%));


### PR DESCRIPTION
## Description

This PR includes cosmetic adjustments to the Answers in the Result component. Every answer is surrounded by a coloured border for better visibility.

![Screenshot 2024-05-15 at 13 51 45](https://github.com/openHPI/quiz-recap/assets/22977799/db2c5156-d6ec-4489-9a3d-c6e99cc22530)


This also resolves using the same background on hover as [described in the original issue](https://dev.xikolo.de/youtrack/issue/XI-6385#focus=Change-71-49429.0-0).

## Decisions / Choices I made

We discussed various other design approaches but none of them were found aesthetically pleasing.

## Checklist

- [x] All checks pass successfully
- [x] All related commits are squashed together
- [x] The changes are properly documented / the relevant documentation is updated (if applicable)
- [x] Appropriate labels are added to this pull request
