### PR TITLE
Fix space for image showing up in results table

### DIFF
--- a/src/components/ResultViewer.module.scss
+++ b/src/components/ResultViewer.module.scss
@@ -14,6 +14,9 @@
     *:not(pre) {
       display: inline;
     }
+    *:not(:first-child) {
+      display: none;
+    }
   }
 
   .answers {

--- a/src/static/data.ts
+++ b/src/static/data.ts
@@ -177,11 +177,18 @@ export const exampleData: Data = [
     text: `![Image](https://picsum.photos/600/200)`,
     answers: [
       { id: 'a', correct: true, text: 'Nice image' },
-      {
-        id: 'b',
-        correct: false,
-        text: 'Ugly image',
-      },
+      { id: 'b', correct: false, text: 'Ugly image' },
+    ],
+  },
+  {
+    id: '13',
+    type: QuestionTypes.SingleChoice,
+    text: `Is this a picture of a cat?
+
+![Image](https://picsum.photos/id/275/600/300)`,
+    answers: [
+      { id: 'a', correct: true, text: "That's not a cat." },
+      { id: 'b', correct: false, text: 'Yes, nice cat.' },
     ],
   },
 ];


### PR DESCRIPTION
## Description

This PR aims to resolve the problem described in #107.
If there is a text before an image, it will be shown too large in the results table.

## Decisions / Choices I made

For a universal solution, I decided to hide every element but the first.
This way, we reduce potential error sources.

## Checklist

- [x] All checks pass successfully
- [x] All related commits are squashed together
- [x] The changes are properly documented / the relevant documentation is updated (if applicable)
- [x] Appropriate labels are added to this pull request
