### PR TITLE
Fix ci build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ name: CI
 
 on:
   push:
-    branches: ['main']
+    branches:
   pull_request:
     branches: ['main']
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,13 @@ import { defineConfig } from 'vitest/config';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), dts({ rollupTypes: true })],
+  plugins: [
+    react(),
+    dts({
+      rollupTypes: true,
+      include: ['src/**/*'],
+    }),
+  ],
   build: {
     lib: {
       entry: resolve(__dirname, 'src/main.tsx'),


### PR DESCRIPTION
## Description

Before, we had an error in the CI build for the project:

```
Run npm run build

> @openhpi/quiz-recap@2.0.0 build
> tsc && vite build

vite v6.3.5 building for production...
transforming...
✓ 340 modules transformed.
rendering chunks...

[vite:dts] Start generate declaration files...
computing gzip size...
[vite:dts] Start rollup declaration files...
Analysis will use the bundled TypeScript version 5.8.2
*** The target project appears to use TypeScript 5.9.2 which is newer than the bundled compiler engine; consider upgrading API Extractor.
✗ Build failed in 6.87s
error during build:
[vite:dts] Internal Error: Unable to follow symbol for "React"

You have encountered a software defect. Please consider reporting the issue to the maintainers of this application.
    at AstSymbolTable._analyzeChildTree (/home/runner/work/quiz-recap/quiz-recap/node_modules/@microsoft/api-extractor/lib/analyzer/AstSymbolTable.js:338:43)
    at AstSymbolTable._analyzeChildTree (/home/runner/work/quiz-recap/quiz-recap/node_modules/@microsoft/api-extractor/lib/analyzer/AstSymbolTable.js:387:18)
    at AstSymbolTable._analyzeChildTree (/home/runner/work/quiz-recap/quiz-recap/node_modules/@microsoft/api-extractor/lib/analyzer/AstSymbolTable.js:387:18)
    at AstSymbolTable._analyzeChildTree (/home/runner/work/quiz-recap/quiz-recap/node_modules/@microsoft/api-extractor/lib/analyzer/AstSymbolTable.js:387:18)
    at AstSymbolTable._analyzeChildTree (/home/runner/work/quiz-recap/quiz-recap/node_modules/@microsoft/api-extractor/lib/analyzer/AstSymbolTable.js:387:18)
    at AstSymbolTable._analyzeAstSymbol (/home/runner/work/quiz-recap/quiz-recap/node_modules/@microsoft/api-extractor/lib/analyzer/AstSymbolTable.js:257:18)
    at AstSymbolTable.analyze (/home/runner/work/quiz-recap/quiz-recap/node_modules/@microsoft/api-extractor/lib/analyzer/AstSymbolTable.js:123:25)
    at /home/runner/work/quiz-recap/quiz-recap/node_modules/@microsoft/api-extractor/lib/analyzer/ExportAnalyzer.js:263:62
    at Map.forEach (<anonymous>)
    at ExportAnalyzer._collectAllExportsRecursive (/home/runner/work/quiz-recap/quiz-recap/node_modules/@microsoft/api-extractor/lib/analyzer/ExportAnalyzer.js:252:48)
Error: Process completed with exit code 1.
```

This PR fixes the issue by configuring the `vite-plugin-dts` plugin to only generate types from the `src` directory.

## Decisions / Choices I made

I decided to additionally let the actions run on every branch so we get feedback before opening an PR.

## Checklist

- [x] All checks pass successfully
- [x] All related commits are squashed together
- [x] The changes are properly documented / the relevant documentation is updated (if applicable)
- [x] Appropriate labels are added to this pull request
